### PR TITLE
Updates to upsampling, downsampling, level, and other fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1299,25 +1299,6 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
-name = "importlib-resources"
-version = "6.4.0"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
-    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1386,7 +1367,6 @@ prompt-toolkit = ">=3.0.41,<3.1.0"
 pygments = ">=2.4.0"
 stack-data = "*"
 traitlets = ">=5"
-typing-extensions = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
@@ -1548,7 +1528,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 jupyter-core = ">=4.12,<5.0.0 || >=5.1.0"
 python-dateutil = ">=2.8.2"
 pyzmq = ">=23.0"
@@ -1619,7 +1598,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 jupyter-server = ">=1.1.2"
 
 [[package]]
@@ -1694,7 +1672,6 @@ files = [
 [package.dependencies]
 async-lru = ">=1.0.0"
 httpx = ">=0.25.0"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 ipykernel = ">=6.5.0"
 jinja2 = ">=3.0.3"
 jupyter-core = "*"
@@ -1740,7 +1717,6 @@ files = [
 
 [package.dependencies]
 babel = ">=2.10"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.10\""}
 jinja2 = ">=3.0.3"
 json5 = ">=0.9.0"
 jsonschema = ">=4.18.0"
@@ -2008,7 +1984,6 @@ files = [
 contourpy = ">=1.0.1"
 cycler = ">=0.10"
 fonttools = ">=4.22.0"
-importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
 kiwisolver = ">=1.3.1"
 numpy = ">=1.23"
 packaging = ">=20.0"
@@ -2251,7 +2226,6 @@ files = [
 beautifulsoup4 = "*"
 bleach = "!=5.0.0"
 defusedxml = "*"
-importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
 jinja2 = ">=3.0"
 jupyter-core = ">=4.7"
 jupyterlab-pygments = "*"
@@ -4092,5 +4066,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.9,<4.0"
-content-hash = "74626218a0d369560b3d3a7f74a55833faf4fe077942ceb3cb1f29a4b9d9ab86"
+python-versions = ">=3.10,<4.0"
+content-hash = "699a0ab51f9238ccef205035781af177ad7f3458296a78b52bf18693bb2d831e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "zarrnii"}]
 
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 zarr = "^2.17.0"
 nibabel = "^5.2.0"
 dask = "^2024.2.0"

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -1,0 +1,18 @@
+from test_io import nifti_nib, cleandir
+import pytest
+import numpy as np
+from numpy.testing import assert_array_almost_equal, assert_array_equal
+from zarrnii import ZarrNii
+
+@pytest.mark.usefixtures("cleandir")
+def test_downsample(nifti_nib):
+
+    nifti_nib.to_filename("test.nii")
+    znimg = ZarrNii.from_path("test.nii")
+    
+    ds=np.array([2,5,8])
+    znimg_downsampled = znimg.downsample(along_x=ds[0],along_y=ds[1],along_z=ds[2])
+   
+    #check size is same as expected size
+    assert_array_equal(znimg.darr.shape[1:],znimg_downsampled.darr.shape[1:] * ds)
+

--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -16,9 +16,19 @@ from attrs import define
 from dask.diagnostics import ProgressBar
 from ome_zarr.scale import Scaler
 from ome_zarr.writer import write_image
+from scipy.ndimage import zoom
 
 from .enums import ImageType
 from .transform import interp_by_block
+
+def zoom_blocks(x,block_info):
+    
+    # get desired scaling by comparing input shape to output shape
+    # block_info[None] is the output block info
+    scaling = tuple(out_n / in_n for out_n,in_n in zip(block_info[None]['chunk-shape'],x.shape))
+
+    return zoom(x,scaling,order=1,prefilter=False)
+
 
 
 @define
@@ -393,7 +403,10 @@ class ZarrNii:
         )
         group = zarr.group(store, overwrite=True)
 
-        scaler = Scaler(max_layer=max_layer, method=scaling_method)
+        if max_layer ==0:
+            scaler = None
+        else:
+            scaler = Scaler(max_layer=max_layer, method=scaling_method)
 
         with ProgressBar():
             write_image(
@@ -474,30 +487,104 @@ class ZarrNii:
         return ZarrNii.from_darr(darr_scaled,vox2ras=new_vox2ras,axes_nifti=self.axes_nifti)
 
 
-    def upsample(self,along_x=1,along_y=1,along_z=1):
-        """ upsamples with scipy.ndimage.zoom"""
-        from scipy.ndimage import zoom
-        #we run map_blocks with chunk sizes modulated by upsampling rate
+    def __get_upsampled_chunks(self, target_shape,return_scaling=True):
+        """ given a target shape, this calculates new chunking 
+        by scaling the input chunks by a scaling factor, adjusting the
+        last chunk if needed. This can be used for upsampling the data, 
+        or ensuring 1-1 correspondence between downsampled and upsampled arrays"""
 
-        if self.axes_nifti:
-            scaling = (1,along_x, along_y, along_z)
+        new_chunks = []
+        scaling = []
+
+        for dim, (orig_shape, orig_chunks, new_shape) in enumerate(zip(self.darr.shape, self.darr.chunks, target_shape)):
+            # Calculate the scaling factor for this dimension
+            scaling_factor = new_shape / orig_shape
+
+            # Scale each chunk size and round to get an initial estimate
+            scaled_chunks = [int(round(chunk * scaling_factor)) for chunk in orig_chunks]
+            total = sum(scaled_chunks)
+            
+            # Adjust the chunks to ensure they sum up to the target shape exactly
+            diff = new_shape - total
+            if diff != 0:
+                # Correct rounding errors by adjusting the last chunk size in the dimension
+                scaled_chunks[-1] += diff
+
+            new_chunks.append(tuple(scaled_chunks))
+            scaling.append(scaling_factor)
+        if return_scaling:
+            return (tuple(new_chunks),scaling)
         else:
-            scaling = (1,along_z, along_y, along_x)
+            return new_chunks
 
-        chunks_in = self.darr.chunks
-        chunks_out = tuple(tuple(c * scale for c in chunks_i) for chunks_i, scale in zip(chunks_in, scaling))
 
-        darr_scaled = da.map_blocks(lambda x: zoom(x,scaling),
+    def divide_by_downsampled(self,znimg_ds):
+        """takes current darr and divides by another darr (which is a downsampled version)"""
+
+        #first, given the chunks of the downsampled darr and the high-res shape, 
+        # we get the upsampled chunks (ie these chunks then have 1-1 correspondence
+        # with downsampled
+        target_chunks = znimg_ds.__get_upsampled_chunks(self.darr.shape,return_scaling=False)
+
+        #we rechunk our original high-res image to that chunking 
+        darr_rechunk = self.darr.rechunk(chunks=target_chunks)
+        
+        #now, self.darr and znimg_ds.darr have matching blocks
+        #so we can use map_blocks to perform operation
+
+        def block_zoom_and_divide_by(x1,x2,block_info):
+            """ this zooms x2 to the size of x1, then does x1 / x2"""
+            # get desired scaling by x2 to x1
+
+            scaling = tuple(n_1 / n_2 for n_1,n_2 in zip(x1.shape,x2.shape))
+
+            return x1 / zoom(x2,scaling,order=1,prefilter=False)
+
+        darr_div = da.map_blocks(
+                    block_zoom_and_divide_by,
+                    darr_rechunk,
+                    znimg_ds.darr,
+                    dtype=self.darr.dtype)
+
+
+        return ZarrNii(darr_div,self.vox2ras,self.ras2vox,self.axes_nifti)
+
+
+    def upsample(self,along_x=1,along_y=1,along_z=1,to_shape=None):
+        """ upsamples with scipy.ndimage.zoom
+            specify either along_x/along_y/along_z, or the target
+            shape with to_shape=(c,z,y,x) or (c,x,y,z) if nifti axes
+            
+            note: this doesn't work yet if self has axes_nifti=True"""
+        
+        
+        #we run map_blocks with chunk sizes modulated by upsampling rate
+        if to_shape == None:
+            if self.axes_nifti:
+                scaling = (1,along_x, along_y, along_z)
+            else:
+                scaling = (1,along_z, along_y, along_x)
+
+            chunks_out = tuple(tuple(c * scale for c in chunks_i) for chunks_i, scale in zip(self.darr.chunks, scaling))
+
+        else:
+            chunks_out,scaling = self.__get_upsampled_chunks(to_shape)
+
+        
+        darr_scaled = da.map_blocks(zoom_blocks,
                     self.darr,
                     dtype=self.darr.dtype,
                     chunks=chunks_out)
 
 
         #we need to also update the affine, scaling by the ds_factor
-        scaling_matrix = np.diag((1/along_x,1/along_y,1/along_z,1))
+        if self.axes_nifti:
+            scaling_matrix = np.diag((1/scaling[1],1/scaling[2],1/scaling[3],1))
+        else:
+            scaling_matrix = np.diag((1/scaling[-1],1/scaling[-2],1/scaling[-3],1))
         new_vox2ras = scaling_matrix @ self.vox2ras.affine
 
-        return ZarrNii.from_darr(darr_scaled,vox2ras=new_vox2ras,axes_nifti=self.axes_nifti)
+        return ZarrNii.from_darr(darr_scaled.rechunk(),vox2ras=new_vox2ras,axes_nifti=self.axes_nifti)
 
 
 

--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -471,14 +471,11 @@ class ZarrNii:
 
 
 
-    def downsample(self,along_x=1,along_y=1,along_z=1,level=None,do_normalized_sum=False,z_level_offset=-2):
+    def downsample(self,along_x=1,along_y=1,along_z=1,level=None,z_level_offset=-2):
         """ Downsamples by local mean. Can either specify along_x,along_y,along_z, 
             or specify the level, and the downsampling factors will be calculated, 
-            taking into account the z_level_offset.
+            taking into account the z_level_offset."""
 
-            Setting do_normalized_sum=True uses a local sum intead of a local mean
-            and normalizes by the product of the local dimensions (ie # of local voxels). 
-            This is used for calculating a field fraction from a mask."""
 
         if level is not None:
             along_x = 2**level
@@ -498,13 +495,7 @@ class ZarrNii:
                                                         2: along_y,
                                                         3: along_x}
 
-        def norm_sum(x, *args, **kwargs):
-            return np.sum(x, *args, **kwargs) / float(along_x*along_y*along_z)
-        
-        if do_normalized_sum:
-            agg_func = norm_sum
-        else:
-            agg_func = np.mean
+        agg_func = np.mean
 
         #coarsen performs a reduction in a local neighbourhood, defined by axes
         #TODO: check if astype is needed..


### PR DESCRIPTION
New features:
 - upsample function
 - seamless use of downsampling when level is selected above the max levels

Fix:
 - remove compatibility with python3.9 or lower as type hints in tests were incompatible