### PR TITLE
Bugfix patch for reading/writing ome-zarr

### DIFF
--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -815,7 +815,7 @@ class ZarrNii:
         #  voxdim = np.flip(voxdim)  # Adjust voxel dimensions to ZYX
         else:
             out_darr = self.darr
-            out_affine = self.affine
+            out_affine = self.affine.matrix
 
         # Extract offset and voxel dimensions from the affine matrix
         offset = out_affine[:3, 3]


### PR DESCRIPTION
- fix (matrix obj vs array) in dealing with affine when writing ome zarr
- fix in from_ome_zarr when rechunk and downsample combined
  - since when we set chunks we are referring to the extracted level, we need to perform the downsampling first, so the shape is what we expect.
   - also cleaned up the funciton a bit.