### PR TITLE
Remove flake8 linting from quality-check.sh

### DIFF
--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -23,17 +23,6 @@ fi
 echo "✅ Import sorting looks good"
 echo ""
 
-echo "📝 Running linting with flake8..."
-# Count the number of linting issues
-LINT_ISSUES=$(uv run flake8 . | wc -l)
-if [ $LINT_ISSUES -gt 0 ]; then
-    echo "⚠️  Found $LINT_ISSUES linting issues (this is expected for existing code)"
-    echo "   Run 'uv run flake8 .' to see details"
-    echo "   Note: These are pre-existing issues and don't block CI"
-else
-    echo "✅ No linting issues found"
-fi
-echo ""
 
 echo "🧪 Testing basic import..."
 uv run python -c "from zarrnii import ZarrNii; print('✅ Import successful')"
@@ -59,7 +48,6 @@ echo ""
 echo "🎉 Quality checks completed!"
 echo "   - Black formatting: enforced (line-length: 88)"
 echo "   - Import sorting: enforced (profile: black)"
-echo "   - Flake8 linting: checked (max-line-length: 88)"
 echo "   - Import test: passed"
 echo "   - Documentation: built" 
 echo "   - Package build: successful"


### PR DESCRIPTION
Removed flake8 linting checks from the quality check script. Was being skipped when failed anyways.