### PR TITLE
Refactor scaled_processing

### DIFF
--- a/packages/zarrnii_plugin_api/zarrnii_plugin_api/_version.py
+++ b/packages/zarrnii_plugin_api/zarrnii_plugin_api/_version.py
@@ -28,7 +28,7 @@ version_tuple: VERSION_TUPLE
 commit_id: COMMIT_ID
 __commit_id__: COMMIT_ID
 
-__version__ = version = '0.16.2a2.dev4'
-__version_tuple__ = version_tuple = (0, 16, 2, 'a2', 'dev4')
+__version__ = version = '0.1.dev4'
+__version_tuple__ = version_tuple = (0, 1, 'dev4')
 
 __commit_id__ = commit_id = None

--- a/tests/test_scaled_processing_plugins.py
+++ b/tests/test_scaled_processing_plugins.py
@@ -59,18 +59,14 @@ class TestScaledProcessingPlugin:
         assert lowres_result.shape == test_lowres.shape
         np.testing.assert_array_equal(lowres_result, test_lowres)
 
-        # Test highres function - now both arrays should be same size
-        test_fullres = da.from_array(
-            np.random.rand(20, 20).astype(np.float32), chunks=(10, 10)
-        )
+        # Test highres function - now both arrays are NumPy arrays (block-level)
+        test_fullres = np.random.rand(20, 20).astype(np.float32)
         # Create upsampled version (same size as fullres for new interface)
-        upsampled_result = da.from_array(lowres_result, chunks=(10, 10))
+        upsampled_result = lowres_result
         highres_result = plugin.highres_func(test_fullres, upsampled_result)
         assert highres_result.shape == test_fullres.shape
         # Result should be double the original
-        np.testing.assert_array_almost_equal(
-            highres_result.compute(), test_fullres.compute() * 2
-        )
+        np.testing.assert_array_almost_equal(highres_result, test_fullres * 2)
 
 
 class TestGaussianBiasFieldCorrection:
@@ -134,13 +130,9 @@ class TestGaussianBiasFieldCorrection:
         """Test the highres_func with upsampled bias field."""
         plugin = GaussianBiasFieldCorrection()
 
-        # Create test data - both arrays same size now
-        fullres_data = (
-            da.ones((40, 40), chunks=(20, 20), dtype=np.float32) * 100
-        )  # Original image
-        upsampled_bias = (
-            da.ones((40, 40), chunks=(20, 20), dtype=np.float32) * 2
-        )  # Upsampled bias field (same size as fullres)
+        # Create test data - both arrays are NumPy arrays (block-level)
+        fullres_data = np.ones((40, 40), dtype=np.float32) * 100  # Original image
+        upsampled_bias = np.ones((40, 40), dtype=np.float32) * 2  # Upsampled bias field
 
         result = plugin.highres_func(fullres_data, upsampled_bias)
 
@@ -148,28 +140,22 @@ class TestGaussianBiasFieldCorrection:
         assert result.shape == fullres_data.shape
 
         # Result should be approximately original divided by bias (100/2 = 50)
-        result_computed = result.compute()
         expected = 50.0
-        assert_array_almost_equal(
-            result_computed, np.full_like(result_computed, expected), decimal=1
-        )
+        assert_array_almost_equal(result, np.full_like(result, expected), decimal=1)
 
     def test_highres_func_division_by_zero_protection(self):
         """Test highres_func protects against division by zero."""
         plugin = GaussianBiasFieldCorrection()
 
         # Test with some zero values in bias field
-        fullres_data = da.ones((20, 20), chunks=(10, 10), dtype=np.float32) * 100
-        upsampled_bias = da.zeros(
-            (20, 20), chunks=(10, 10), dtype=np.float32
-        )  # All zeros
+        fullres_data = np.ones((20, 20), dtype=np.float32) * 100
+        upsampled_bias = np.zeros((20, 20), dtype=np.float32)  # All zeros
 
         result = plugin.highres_func(fullres_data, upsampled_bias)
 
         assert result.shape == fullres_data.shape
         # Should not result in inf values
-        result_computed = result.compute()
-        assert np.all(np.isfinite(result_computed))
+        assert np.all(np.isfinite(result))
 
 
 class TestZarrNiiScaledProcessingIntegration:
@@ -251,48 +237,38 @@ class TestZarrNiiScaledProcessingIntegration:
             znimg.apply_scaled_processing("not_a_plugin")
 
     @pytest.mark.usefixtures("cleandir")
-    def test_apply_scaled_processing_with_custom_chunks(self, nifti_nib):
-        """Test apply_scaled_processing with custom chunk size (spatial dimensions only)."""
+    def test_apply_scaled_processing_basic(self, nifti_nib):
+        """Test apply_scaled_processing basic usage with a plugin instance."""
         nifti_nib.to_filename("test.nii")
         znimg = ZarrNii.from_nifti("test.nii", axes_order="ZYX")
 
         plugin = GaussianBiasFieldCorrection(sigma=1.0)
-        # chunk_size now only specifies spatial dimensions (Z, Y, X)
-        result = znimg.apply_scaled_processing(
-            plugin, downsample_factor=2, chunk_size=(32, 32, 32)
-        )
+        # map_blocks approach does not need a chunk_size parameter
+        result = znimg.apply_scaled_processing(plugin, downsample_factor=2)
 
         assert isinstance(result, ZarrNii)
         assert result.shape == znimg.shape
 
     @pytest.mark.usefixtures("cleandir")
-    def test_apply_scaled_processing_temp_zarr_options(self, nifti_nib):
-        """Test apply_scaled_processing with temp zarr options."""
+    def test_apply_scaled_processing_unknown_kwargs_with_instance_raises(
+        self, nifti_nib
+    ):
+        """Test apply_scaled_processing raises TypeError for unknown kwargs with instance."""
         nifti_nib.to_filename("test.nii")
         znimg = ZarrNii.from_nifti("test.nii", axes_order="ZYX")
 
         plugin = GaussianBiasFieldCorrection(sigma=1.0)
 
-        # Test with temp zarr disabled
-        result1 = znimg.apply_scaled_processing(
-            plugin, downsample_factor=2, use_temp_zarr=False
-        )
-        assert isinstance(result1, ZarrNii)
-        assert result1.shape == znimg.shape
-
-        # Test with custom temp zarr path
-        import os
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = os.path.join(temp_dir, "custom_temp.ome.zarr")
-            result2 = znimg.apply_scaled_processing(
-                plugin, downsample_factor=2, temp_zarr_path=temp_path
+        # Passing unknown kwargs with an instance should raise TypeError
+        with pytest.raises(TypeError, match="unexpected keyword arguments"):
+            znimg.apply_scaled_processing(
+                plugin, downsample_factor=2, use_temp_zarr=False
             )
-            assert isinstance(result2, ZarrNii)
-            assert result2.shape == znimg.shape
-            # Temp file should be cleaned up
-            assert not os.path.exists(temp_path)
+
+        with pytest.raises(TypeError, match="unexpected keyword arguments"):
+            znimg.apply_scaled_processing(
+                plugin, downsample_factor=2, temp_zarr_path="/tmp/test.zarr"
+            )
 
     @pytest.mark.usefixtures("cleandir")
     def test_apply_scaled_processing_5d_data(self):
@@ -315,8 +291,8 @@ class TestZarrNiiScaledProcessingIntegration:
         assert len(result.dims) == 5
 
     @pytest.mark.usefixtures("cleandir")
-    def test_apply_scaled_processing_5d_data_custom_chunks(self):
-        """Test apply_scaled_processing with 5D data and custom spatial chunks."""
+    def test_apply_scaled_processing_5d_data_plugin_instance_with_invalid_kwargs(self):
+        """Test apply_scaled_processing raises TypeError when kwargs passed with instance."""
         # Create 5D test data with singleton time and channel dimensions
         data_5d = np.random.rand(1, 1, 20, 20, 20).astype(np.float32) * 100
         dask_data = da.from_array(data_5d, chunks=(1, 1, 10, 10, 10))
@@ -327,14 +303,11 @@ class TestZarrNiiScaledProcessingIntegration:
 
         plugin = GaussianBiasFieldCorrection(sigma=1.0)
 
-        # Test with custom spatial chunk size (only Z, Y, X)
-        result = znimg_5d.apply_scaled_processing(
-            plugin, downsample_factor=2, chunk_size=(16, 16, 16)
-        )
-
-        assert isinstance(result, ZarrNii)
-        assert result.shape == znimg_5d.shape
-        assert len(result.dims) == 5
+        # Passing extra kwargs with a plugin instance should raise TypeError
+        with pytest.raises(TypeError, match="unexpected keyword arguments"):
+            znimg_5d.apply_scaled_processing(
+                plugin, downsample_factor=2, chunk_size=(16, 16, 16)
+            )
 
 
 class TestScaledProcessingWorkflow:
@@ -465,9 +438,9 @@ class TestN4BiasFieldCorrection:
 
         plugin = N4BiasFieldCorrection()
 
-        # Create test data - both arrays same size
-        fullres_data = da.ones((40, 40), chunks=(20, 20), dtype=np.float32) * 100
-        upsampled_bias = da.ones((40, 40), chunks=(20, 20), dtype=np.float32) * 2
+        # Create test data - both arrays are NumPy arrays (block-level)
+        fullres_data = np.ones((40, 40), dtype=np.float32) * 100
+        upsampled_bias = np.ones((40, 40), dtype=np.float32) * 2
 
         result = plugin.highres_func(fullres_data, upsampled_bias)
 
@@ -475,11 +448,8 @@ class TestN4BiasFieldCorrection:
         assert result.shape == fullres_data.shape
 
         # Result should be approximately original divided by bias (100/2 = 50)
-        result_computed = result.compute()
         expected = 50.0
-        assert_array_almost_equal(
-            result_computed, np.full_like(result_computed, expected), decimal=1
-        )
+        assert_array_almost_equal(result, np.full_like(result, expected), decimal=1)
 
     @pytest.mark.skipif(not HAS_ANTSPYX, reason="antspyx not available")
     def test_n4_highres_func_division_by_zero_protection(self):
@@ -489,15 +459,14 @@ class TestN4BiasFieldCorrection:
         plugin = N4BiasFieldCorrection()
 
         # Test with some zero values in bias field
-        fullres_data = da.ones((20, 20), chunks=(10, 10), dtype=np.float32) * 100
-        upsampled_bias = da.zeros((20, 20), chunks=(10, 10), dtype=np.float32)
+        fullres_data = np.ones((20, 20), dtype=np.float32) * 100
+        upsampled_bias = np.zeros((20, 20), dtype=np.float32)
 
         result = plugin.highres_func(fullres_data, upsampled_bias)
 
         assert result.shape == fullres_data.shape
         # Should not result in inf values
-        result_computed = result.compute()
-        assert np.all(np.isfinite(result_computed))
+        assert np.all(np.isfinite(result))
 
     def test_n4_plugin_repr(self):
         """Test N4 plugin string representation."""
@@ -671,17 +640,12 @@ class TestSegmentationCleaner:
 
         plugin = SegmentationCleaner(exclusion_threshold=50)
 
-        # Create full-resolution segmentation data
-        fullres_data = da.ones((40, 40), chunks=(20, 20), dtype=np.float32) * 100
+        # Create full-resolution segmentation data as NumPy arrays (block-level)
+        fullres_data = np.ones((40, 40), dtype=np.float32) * 100
 
-        # Create upsampled exclusion mask
-        # Mark some regions for exclusion (value 100)
-        upsampled_mask = da.zeros((40, 40), chunks=(20, 20), dtype=np.uint8)
-        upsampled_mask = da.where(
-            (da.arange(40).reshape(-1, 1) < 20) & (da.arange(40).reshape(1, -1) < 20),
-            100,
-            0,
-        )
+        # Create upsampled exclusion mask: top-left quadrant is excluded (value 100)
+        upsampled_mask = np.zeros((40, 40), dtype=np.uint8)
+        upsampled_mask[:20, :20] = 100
 
         result = plugin.highres_func(fullres_data, upsampled_mask)
 
@@ -689,12 +653,11 @@ class TestSegmentationCleaner:
         assert result.shape == fullres_data.shape
 
         # Check that excluded regions are zeroed
-        result_computed = result.compute()
         # Top-left quadrant should be zero (excluded)
-        assert np.all(result_computed[:20, :20] == 0)
+        assert np.all(result[:20, :20] == 0)
         # Other regions should remain at 100
-        assert np.all(result_computed[20:, :] == 100)
-        assert np.all(result_computed[:, 20:] == 100)
+        assert np.all(result[20:, :] == 100)
+        assert np.all(result[:, 20:] == 100)
 
     def test_highres_func_threshold_boundary(self):
         """Test highres_func threshold behavior."""
@@ -704,22 +667,19 @@ class TestSegmentationCleaner:
 
         plugin = SegmentationCleaner(exclusion_threshold=50)
 
-        # Create full-resolution data
-        fullres_data = da.ones((20, 20), chunks=(10, 10), dtype=np.float32) * 100
+        # Create full-resolution data as NumPy arrays (block-level)
+        fullres_data = np.ones((20, 20), dtype=np.float32) * 100
 
         # Create exclusion mask with values at threshold boundary
-        upsampled_mask = da.full((20, 20), 49, chunks=(10, 10), dtype=np.uint8)
-        upsampled_mask = da.where(
-            da.arange(20).reshape(-1, 1) < 10, 50, upsampled_mask
-        )  # Set half to exactly 50
+        upsampled_mask = np.full((20, 20), 49, dtype=np.uint8)
+        upsampled_mask[:10, :] = 50  # Set top half to exactly 50
 
         result = plugin.highres_func(fullres_data, upsampled_mask)
-        result_computed = result.compute()
 
         # Values >= 50 should be excluded (zeroed)
-        assert np.all(result_computed[:10, :] == 0)
+        assert np.all(result[:10, :] == 0)
         # Values < 50 should be preserved
-        assert np.all(result_computed[10:, :] == 100)
+        assert np.all(result[10:, :] == 100)
 
     def test_segmentation_cleaner_integration(self):
         """Test complete segmentation cleaning workflow."""
@@ -751,12 +711,9 @@ class TestSegmentationCleaner:
         # Should have some exclusion mask
         assert np.any(lowres_result > 0)
 
-        # Test highres function
-        fullres_data = da.from_array(test_data, chunks=(50, 50))
-        upsampled_mask = da.from_array(lowres_result, chunks=(50, 50))
-
-        highres_result = plugin.highres_func(fullres_data, upsampled_mask)
-        cleaned = highres_result.compute()
+        # Test highres function - now accepts/returns NumPy arrays
+        highres_result = plugin.highres_func(test_data, lowres_result)
+        cleaned = highres_result
 
         # Verify that data was cleaned
         assert cleaned.shape == test_data.shape

--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -5631,18 +5631,28 @@ class ZarrNii:
         1. The image is downsampled for efficient computation
         2. The plugin's lowres_func is applied to the downsampled data
         3. The result is upsampled and highres_func applied in single map_blocks
+
         Args:
             plugin: Plugin instance or class to apply.  The plugin must have
-                ``lowres_func(lowres_array)`` and ``highres_func(fullres_array,
-                upsampled_output)`` methods decorated with ``@hookimpl`` from
-                :mod:`zarrnii_plugin_api`.
+                ``lowres_func(lowres_array: np.ndarray) -> np.ndarray`` and
+                ``highres_func(fullres_block: np.ndarray, upsampled_block:
+                np.ndarray) -> np.ndarray`` methods decorated with ``@hookimpl``
+                from :mod:`zarrnii_plugin_api`.
             downsample_factor: Factor for downsampling (default: 4)
-            **kwargs: Additional arguments passed to the plugin when *plugin* is a class.
+            **kwargs: Additional arguments passed to the plugin constructor when
+                *plugin* is a class.  Passing kwargs together with a plugin
+                *instance* raises :class:`TypeError`.
         Returns:
             New ZarrNii instance with processed data
         """
         if isinstance(plugin, type):
             plugin = plugin(**kwargs)
+        elif kwargs:
+            raise TypeError(
+                f"apply_scaled_processing() received unexpected keyword arguments "
+                f"for a plugin instance: {list(kwargs.keys())}. "
+                f"Keyword arguments are only accepted when 'plugin' is a class."
+            )
 
         if not callable(getattr(plugin, "lowres_func", None)) or not callable(
             getattr(plugin, "highres_func", None)
@@ -5657,55 +5667,79 @@ class ZarrNii:
         lowres_array = lowres_znimg.data.compute()
         lowres_result = plugin.lowres_func(lowres_array)
 
+        # Determine which dims are spatial vs non-spatial using self.dims
+        _spatial_dim_names = {"x", "y", "z"}
+        _dims = self.dims  # e.g. ['c', 'z', 'y', 'x'] or ['t', 'c', 'z', 'y', 'x']
+        _is_spatial = [d.lower() in _spatial_dim_names for d in _dims]
+        _nonspatial_idxs = [i for i, s in enumerate(_is_spatial) if not s]
+        _spatial_idxs = [i for i, s in enumerate(_is_spatial) if s]
+
+        # Determine output dtype by probing highres_func with a tiny (1-element)
+        # test block.  Plugins must handle single-element arrays correctly.
+        _probe_full = np.ones((1,) * len(_dims), dtype=self.data.dtype)
+        _probe_up = np.ones((1,) * len(_dims), dtype=np.float32)
+        _output_dtype = np.asarray(plugin.highres_func(_probe_full, _probe_up)).dtype
+
         # Step 2: Fused map_blocks — interpolate + apply highres in one pass
         def _fused_block(block, block_info=None):
-            """For each full-res block, interpolate the lowres correction
-            map at the corresponding coordinates, then apply highres_func."""
-            arr_loc = block_info[0]["array-location"]
+            """For each full-res block, interpolate the lowres correction map at
+            the corresponding coordinates using only spatial axes, then apply
+            highres_func."""
+            import itertools
 
-            # Build coordinate grids for this block in lowres space
-            # Each full-res index i maps to lowres index i / downsample_factor
-            slices = []
-            for dim_idx in range(len(block.shape)):
-                start, stop = arr_loc[dim_idx]
-                if dim_idx == 0:
-                    # Non-spatial (channel) — direct index
-                    slices.append(np.arange(start, stop))
-                else:
-                    # Spatial — map to lowres coordinates
-                    slices.append(
-                        np.arange(start, stop).astype(np.float64) / downsample_factor
-                    )
-
-            # Interpolate lowres_result at these coordinates
-            # For spatial dims, use scipy.ndimage.map_coordinates for efficiency
             from scipy.ndimage import map_coordinates
 
-            upsampled_block = np.empty_like(block, dtype=np.float32)
+            arr_loc = block_info[0]["array-location"]
 
-            for c_idx, c in enumerate(range(arr_loc[0][0], arr_loc[0][1])):
-                # Build coordinate arrays for this channel's spatial block
-                spatial_slices = slices[1:]  # skip channel dim
-                grids = np.meshgrid(*spatial_slices, indexing="ij")
-                coords = np.array([g.ravel() for g in grids])
+            # Build spatial coordinate arrays scaled to lowres space
+            spatial_slices = [
+                np.arange(arr_loc[i][0], arr_loc[i][1]).astype(np.float64)
+                / downsample_factor
+                for i in _spatial_idxs
+            ]
+            spatial_block_shape = tuple(block.shape[i] for i in _spatial_idxs)
 
-                # Interpolate from the lowres result
+            # Pre-compute meshgrid coords (same for all non-spatial combinations)
+            grids = np.meshgrid(*spatial_slices, indexing="ij")
+            coords = np.array([g.ravel() for g in grids])
+
+            # Non-spatial absolute index ranges for looping
+            nonspatial_ranges = [
+                list(range(arr_loc[i][0], arr_loc[i][1])) for i in _nonspatial_idxs
+            ]
+
+            upsampled_block = np.empty(block.shape, dtype=np.float32)
+
+            for ns_abs in itertools.product(*nonspatial_ranges):
+                # Relative indices within this block for non-spatial dims
+                ns_rel = tuple(
+                    abs_idx - arr_loc[_nonspatial_idxs[j]][0]
+                    for j, abs_idx in enumerate(ns_abs)
+                )
+
+                # Build per-dim selectors: non-spatial dims fixed, spatial dims free
+                block_selector = [slice(None)] * len(_dims)
+                for j, rel_idx in zip(_nonspatial_idxs, ns_rel):
+                    block_selector[j] = rel_idx
+
+                # Interpolate from lowres_result at the non-spatial position
                 interpolated = map_coordinates(
-                    lowres_result[c],
+                    lowres_result[ns_abs] if _nonspatial_idxs else lowres_result,
                     coords,
                     order=1,
                     mode="nearest",
-                ).reshape(block.shape[1:])
+                ).reshape(spatial_block_shape)
 
-                upsampled_block[c_idx] = interpolated
-            # Apply the highres function element-wise
+                upsampled_block[tuple(block_selector)] = interpolated
+
+            # Apply the highres function block-wise (NumPy in, NumPy out)
             return plugin.highres_func(block, upsampled_block)
 
         corrected_znimg = self.copy()
         corrected_znimg.data = da.map_blocks(
             _fused_block,
             self.data,
-            dtype=self.data.dtype,
+            dtype=_output_dtype,
         )
 
         return corrected_znimg

--- a/zarrnii/plugins/scaled_processing/gaussian_biasfield.py
+++ b/zarrnii/plugins/scaled_processing/gaussian_biasfield.py
@@ -7,9 +7,6 @@ at low resolution and applies it to full resolution data.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-
-import dask.array as da
 import numpy as np
 from scipy import ndimage
 from zarrnii_plugin_api import hookimpl
@@ -105,8 +102,8 @@ class GaussianBiasFieldCorrection:
 
     @hookimpl
     def highres_func(
-        self, fullres_array: da.Array, upsampled_output: da.Array
-    ) -> da.Array:
+        self, fullres_array: np.ndarray, upsampled_output: np.ndarray
+    ) -> np.ndarray:
         """
         Apply bias field correction to full-resolution data.
 
@@ -114,18 +111,18 @@ class GaussianBiasFieldCorrection:
         and applies it to the full-resolution data by division.
 
         Args:
-            fullres_array: Full-resolution dask array
+            fullres_array: Full-resolution NumPy array (one block)
             upsampled_output: Upsampled bias field (same shape as fullres_array)
 
         Returns:
-            Bias-corrected full-resolution array
+            Bias-corrected full-resolution array (float32)
         """
-        # Apply bias field correction by division using dask operations
-        # Avoid division by zero by adding small epsilon
+        # Apply bias field correction by division using NumPy operations.
+        # Avoid division by zero by clamping the bias field to a small epsilon.
         epsilon = np.finfo(np.float32).eps
-        corrected_array = fullres_array / da.maximum(upsampled_output, epsilon)
+        corrected_array = fullres_array / np.maximum(upsampled_output, epsilon)
 
-        return corrected_array
+        return corrected_array.astype(np.float32)
 
     @hookimpl
     def scaled_processing_plugin_name(self) -> str:

--- a/zarrnii/plugins/scaled_processing/n4_biasfield.py
+++ b/zarrnii/plugins/scaled_processing/n4_biasfield.py
@@ -8,9 +8,6 @@ resolution data.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-
-import dask.array as da
 import numpy as np
 from zarrnii_plugin_api import hookimpl
 
@@ -153,8 +150,8 @@ class N4BiasFieldCorrection:
 
     @hookimpl
     def highres_func(
-        self, fullres_array: da.Array, upsampled_output: da.Array
-    ) -> da.Array:
+        self, fullres_array: np.ndarray, upsampled_output: np.ndarray
+    ) -> np.ndarray:
         """
         Apply bias field correction to full-resolution data.
 
@@ -162,18 +159,18 @@ class N4BiasFieldCorrection:
         fullres_array) and applies it to the full-resolution data by division.
 
         Args:
-            fullres_array: Full-resolution dask array
+            fullres_array: Full-resolution NumPy array (one block)
             upsampled_output: Upsampled bias field (same shape as fullres)
 
         Returns:
-            Bias-corrected full-resolution array
+            Bias-corrected full-resolution array (float32)
         """
-        # Apply bias field correction by division using dask operations
-        # Avoid division by zero by adding small epsilon
+        # Apply bias field correction by division using NumPy operations.
+        # Avoid division by zero by clamping the bias field to a small epsilon.
         epsilon = np.finfo(np.float32).eps
-        corrected_array = fullres_array / da.maximum(upsampled_output, epsilon)
+        corrected_array = fullres_array / np.maximum(upsampled_output, epsilon)
 
-        return corrected_array
+        return corrected_array.astype(np.float32)
 
     @hookimpl
     def scaled_processing_plugin_name(self) -> str:

--- a/zarrnii/plugins/scaled_processing/segmentation_cleaner.py
+++ b/zarrnii/plugins/scaled_processing/segmentation_cleaner.py
@@ -9,7 +9,6 @@ resolution data.
 
 from __future__ import annotations
 
-import dask.array as da
 import numpy as np
 from skimage.measure import label, regionprops
 from zarrnii_plugin_api import hookimpl
@@ -123,8 +122,8 @@ class SegmentationCleaner:
 
     @hookimpl
     def highres_func(
-        self, fullres_array: da.Array, upsampled_output: da.Array
-    ) -> da.Array:
+        self, fullres_array: np.ndarray, upsampled_output: np.ndarray
+    ) -> np.ndarray:
         """
         Apply exclusion mask to full-resolution segmentation data.
 
@@ -132,18 +131,18 @@ class SegmentationCleaner:
         the full-resolution segmentation by zeroing out the excluded regions.
 
         Args:
-            fullres_array: Full-resolution segmentation dask array
+            fullres_array: Full-resolution segmentation NumPy array (one block)
             upsampled_output: Upsampled exclusion mask (same shape as fullres)
 
         Returns:
             Cleaned full-resolution segmentation array
         """
-        # Threshold the upsampled exclusion mask
-        # Values >= exclusion_threshold (e.g., 50) indicate regions to exclude
+        # Threshold the upsampled exclusion mask.
+        # Values >= exclusion_threshold (e.g., 50) indicate regions to exclude.
         exclusion_mask = upsampled_output >= self.exclusion_threshold
 
-        # Apply mask: set excluded regions to zero
-        cleaned_array = da.where(exclusion_mask, 0, fullres_array)
+        # Apply mask: set excluded regions to zero using NumPy operations
+        cleaned_array = np.where(exclusion_mask, 0, fullres_array)
 
         return cleaned_array
 


### PR DESCRIPTION
changes how upsampling performed, using map block, where the lowres
version is passed as an arg, instead of the rechunking strategy..
should be more efficient and also don't have to worry about chunk sizes.

note: in spimquant, should make sure data is rechunked before other processing that
works best with 3d chunks (since this would not change chunking from input data).. 