### PR TITLE
Simplify GitHub Release workflow by removing checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  release:
-    types: [published]
 
 env:
   FORCE_COLOR: "1"
@@ -90,23 +88,13 @@ jobs:
           ./dist/*.tar.gz
           ./dist/*.whl
 
-    - name: Create GitHub Release (if not exists)
+    - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}"; then
-          echo "Release '${{ github.ref_name }}' already exists, skipping creation."
-        else
-          gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes ""
-        fi
+      run: gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes ""
 
 
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}"; then
-          echo "Release '${{ github.ref_name }}' already exists, skipping artifact upload."
-        else
-          gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'
-        fi
+      run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         fi
 
 
-    - name: Upload artifact signatures to GitHub Release
+    - name: Upload release artifacts to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: gh release upload '${{ github.ref_name }}' dist/** --clobber --repo '${{ github.repository }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,12 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes ""
+      run: |
+        if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          gh release edit "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes ""
+        else
+          gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --notes ""
+        fi
 
 
     - name: Upload artifact signatures to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,4 +102,4 @@ jobs:
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'
+      run: gh release upload '${{ github.ref_name }}' dist/** --clobber --repo '${{ github.repository }}'


### PR DESCRIPTION
Removed conditional checks for release creation and artifact upload in the GitHub Actions workflow. 
Can do this since the trigger is updated to not run twice for a release.