### PR TITLE
fix bug in loading downsampled levels from imaris

### DIFF
--- a/tests/test_imaris.py
+++ b/tests/test_imaris.py
@@ -115,6 +115,29 @@ class TestImarisIO:
         assert ds_shape[1] == orig_shape[1] // 4
         assert ds_shape[2] == orig_shape[2] // 4
 
+    def test_from_imaris_loads_native_downsampled_levels(self, multi_level_imaris_file):
+        """Test loading native multi-resolution levels from Imaris."""
+        ims_path, _ = multi_level_imaris_file
+
+        with h5py.File(ims_path, "r") as f:
+            expected_level1 = f["DataSet/ResolutionLevel 1/TimePoint 0/Channel 0/Data"][
+                ()
+            ]
+            expected_level2 = f["DataSet/ResolutionLevel 2/TimePoint 0/Channel 0/Data"][
+                ()
+            ]
+
+        znimg_level1 = ZarrNii.from_imaris(ims_path, level=1)
+        znimg_level2 = ZarrNii.from_imaris(ims_path, level=2)
+
+        loaded_level1 = znimg_level1.darr.compute()
+        loaded_level2 = znimg_level2.darr.compute()
+
+        assert loaded_level1.shape == (1,) + expected_level1.shape
+        assert loaded_level2.shape == (1,) + expected_level2.shape
+        assert_array_equal(loaded_level1[0], expected_level1)
+        assert_array_equal(loaded_level2[0], expected_level2)
+
     def test_from_imaris_negative_level_raises(self, sample_imaris_file):
         """Test that a negative level raises ValueError."""
         with pytest.raises(ValueError, match="Level must be >= 0"):

--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -4746,7 +4746,7 @@ class ZarrNii:
         channels: Optional[List[int]] = None,
         channel_labels: Optional[List[str]] = None,
         set_channel_labels: Optional[List[str]] = None,
-        chunks: Optional[tuple[int, Ellipsis]] = None,
+        chunks: Any = None,
         axes_order: str = "ZYX",
         orientation: str = "RAS",
         axes_units: Optional[Dict[str, str]] = None,

--- a/zarrnii/core.py
+++ b/zarrnii/core.py
@@ -4746,7 +4746,7 @@ class ZarrNii:
         channels: Optional[List[int]] = None,
         channel_labels: Optional[List[str]] = None,
         set_channel_labels: Optional[List[str]] = None,
-        chunks: str = "auto",
+        chunks: Optional[tuple[int, Ellipsis]] = None,
         axes_order: str = "ZYX",
         orientation: str = "RAS",
         axes_units: Optional[Dict[str, str]] = None,
@@ -4771,7 +4771,7 @@ class ZarrNii:
             set_channel_labels: Channel labels that define the channels present
                 in the Imaris data, in channel index order. Required when
                 channel_labels is used.
-            chunks: Chunking strategy for dask array
+            chunks: Chunking strategy for dask array (default: use imaris chunking)
             axes_order: Spatial axes order for compatibility (default: "ZYX")
             orientation: Default orientation (default: "RAS")
             axes_units: Optional mapping of axis name to unit string (e.g.
@@ -4831,10 +4831,8 @@ class ZarrNii:
             raise ValueError(f"Unable to read Imaris file '{path}': {exc}") from exc
 
         available_levels = 1
-        if hasattr(level0_store, "ims") and hasattr(
-            level0_store.ims, "ResolutionLevels"
-        ):
-            available_levels = level0_store.ims.ResolutionLevels
+        if hasattr(level0_store, "ResolutionLevels"):
+            available_levels = level0_store.ResolutionLevels
         if level < 0:
             raise ValueError(f"Level {level} not available. Level must be >= 0.")
         max_level = available_levels - 1


### PR DESCRIPTION
was incorrectly assuming the resolution level info was in an ims attribute, when it was in the top level -- causing the max resolution to be always used (and successively downsampled with dask on the fly)..